### PR TITLE
best-friendsのスパム対策をcherry-pick

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -440,7 +440,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def like_a_spam?
     (
       !@status.account.local? &&
-      @status.account.followers_count > SPAM_FILTER_MINIMUM_FOLLOWERS &&
+      @status.account.followers_count <= SPAM_FILTER_MINIMUM_FOLLOWERS &&
       @status.account.created_at > SPAM_FILTER_MINIMUM_CREATE_DAYS.day.ago &&
       @mentions.count > SPAM_FILTER_MINIMUM_MENTIONS
     )

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -86,7 +86,6 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       @status = Status.create!(@params)
       attach_tags(@status)
 
-      # Delete status on zero follower user and nearly created account with include some replies
       if like_a_spam?
         @status = nil
         raise ActiveRecord::Rollback
@@ -435,12 +434,15 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     retry
   end
 
+  SPAM_FILTER_MINIMUM_FOLLOWERS = ENV.fetch('SPAM_FILTER_MINIMUM_FOLLOWERS', 0).to_i
+  SPAM_FILTER_MINIMUM_CREATE_DAYS = ENV.fetch('SPAM_FILTER_MINIMUM_CREATE_DAYS', 1).to_i
+  SPAM_FILTER_MINIMUM_MENTIONS = ENV.fetch('SPAM_FILTER_MINIMUM_MENTIONS', 1).to_i
   def like_a_spam?
     (
       !@status.account.local? &&
-      @status.account.followers_count.zero? &&
-      @status.account.created_at > 1.day.ago &&
-      @mentions.count >= 2
+      @status.account.followers_count > SPAM_FILTER_MINIMUM_FOLLOWERS &&
+      @status.account.created_at > SPAM_FILTER_MINIMUM_CREATE_DAYS.day.ago &&
+      @mentions.count > SPAM_FILTER_MINIMUM_MENTIONS
     )
   end
 end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -85,7 +85,15 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     ApplicationRecord.transaction do
       @status = Status.create!(@params)
       attach_tags(@status)
+
+      # Delete status on zero follower user and nearly created account with include some replies
+      if like_a_spam?
+        @status = nil
+        raise ActiveRecord::Rollback
+      end
     end
+
+    return if @status.nil?
 
     resolve_thread(@status)
     fetch_replies(@status)
@@ -425,5 +433,14 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   rescue ActiveRecord::StaleObjectError
     poll.reload
     retry
+  end
+
+  def like_a_spam?
+    (
+      !@status.account.local? &&
+      @status.account.followers_count.zero? &&
+      @status.account.created_at > 1.day.ago &&
+      @mentions.count >= 2
+    )
   end
 end


### PR DESCRIPTION
アカウント作成日やフォロー状況、メンション数からアクティビティを無視する機能をbest-friendsから取り込み