### PR TITLE
Otadon 4.3.1 R2（機能改善）

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: GitHub Discussions
     url: https://github.com/mastodon/mastodon/discussions

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -15,6 +15,7 @@ import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
 import NotificationsActiveIcon from '@/material-icons/400-24px/notifications_active-fill.svg?react';
 import ShareIcon from '@/material-icons/400-24px/share.svg?react';
+import OpenInNew from '@/material-icons/400-24px/open_in_new.svg?react';
 import { Avatar } from 'mastodon/components/avatar';
 import { Badge, AutomatedBadge, GroupBadge } from 'mastodon/components/badge';
 import { Button } from 'mastodon/components/button';
@@ -34,6 +35,7 @@ import AccountNoteContainer from '../containers/account_note_container';
 import FollowRequestNoteContainer from '../containers/follow_request_note_container';
 
 import { DomainPill } from './domain_pill';
+import RepeatIcon from "@/material-icons/400-24px/repeat.svg";
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
@@ -410,6 +412,20 @@ class Header extends ImmutablePureComponent {
     return (
       <div className={classNames('account__header', { inactive: !!account.get('moved') })} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         {!(suspended || hidden || account.get('moved')) && account.getIn(['relationship', 'requested_by']) && <FollowRequestNoteContainer account={account} />}
+
+        {isRemote && (
+          <div className='account__header__bar'>
+            <div className='remote-user-info-container'>
+              <Icon id='retweet' icon={OpenInNew} />
+              <div className='remote-user-info-text'>
+                <FormattedMessage id='account.info_remote_server' defaultMessage='This is a remote server user.' />
+              </div>
+              <a href={account.get('url')} target='_blank' rel="nofollow noopener noreferrer" className='link-button'>
+                <FormattedMessage id='account.open_original_page' defaultMessage='Open original page'/>
+              </a>
+            </div>
+          </div>
+        )}
 
         <div className='account__header__image'>
           <div className='account__header__info'>

--- a/app/javascript/mastodon/features/home_timeline/components/inline_follow_suggestions.jsx
+++ b/app/javascript/mastodon/features/home_timeline/components/inline_follow_suggestions.jsx
@@ -20,7 +20,7 @@ import { FollowButton } from 'mastodon/components/follow_button';
 import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import { VerifiedBadge } from 'mastodon/components/verified_badge';
-import { domain } from 'mastodon/initial_state';
+import { domain, disableFollowSuggestion } from 'mastodon/initial_state';
 
 const messages = defineMessages({
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
@@ -168,7 +168,7 @@ export const InlineFollowSuggestions = ({ hidden }) => {
     return null;
   }
 
-  if (hidden) {
+  if (hidden || disableFollowSuggestion) {
     return (
       <div className='inline-follow-suggestions' />
     );

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -48,6 +48,7 @@
  * @property {boolean} hide_remote_timeline
  * @property {boolean} hide_federated_timeline
  * @property {boolean} show_otadon_tag_cloud
+ * @property {boolean} disable_follow_suggestion
  */
 
 /**
@@ -128,6 +129,7 @@ export const hideLocalTimeline = getMeta('hide_local_timeline');
 export const hideRemoteTimeline = getMeta('hide_remote_timeline');
 export const hideFederatedTimeline = getMeta('hide_federated_timeline');
 export const showOtadonTagCloud = getMeta('show_otadon_tag_cloud');
+export const disableFollowSuggestion = getMeta('disable_follow_suggestion');
 
 /**
  * @returns {string | undefined}

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -55,6 +55,7 @@
   "account.mutual": "相互フォロー中",
   "account.no_bio": "説明が提供されていません。",
   "account.open_original_page": "元のページを開く",
+  "account.info_remote_server": "リモートサーバーのユーザです。",
   "account.posts": "投稿",
   "account.posts_with_replies": "投稿と返信",
   "account.report": "@{name}さんを通報",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -150,7 +150,7 @@
   "compose.published.open": "開く",
   "compose.saved.body": "変更を保存しました。",
   "compose_form.direct_message_warning_learn_more": "もっと詳しく",
-  "compose_form.encryption_warning": "Mastodonの投稿はエンドツーエンド暗号化に対応していません。安全に送受信されるべき情報をMastodonで共有しないでください。",
+  "compose_form.encryption_warning": "Mastodonの投稿は暗号化されずに保存されます。個人情報や安全に情報のやりとりが必要な場合、別サービス・手段をご利用ください。",
   "compose_form.hashtag_warning": "この投稿は公開設定ではないのでハッシュタグの一覧に表示されません。公開投稿だけがハッシュタグで検索できます。",
   "compose_form.lock_disclaimer": "あなたのアカウントは{locked}になっていません。誰でもあなたをフォローすることができ、フォロワー限定の投稿を見ることができます。",
   "compose_form.lock_disclaimer.lock": "承認制",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -11282,3 +11282,15 @@ noscript {
     background-image: url('../images/filter-stripes.svg');
   }
 }
+
+.remote-user-info-container {
+  display: flex;
+  flex-direction: row;
+  padding: 12px 0;
+  gap: 4px;
+}
+
+.remote-user-info-text {
+  font-size: 15px;
+  line-height: 20px;
+}

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -154,4 +154,8 @@ module User::HasSettings
   def show_otadon_tag_cloud
     settings['show_otadon_tag_cloud']
   end
+
+  def disable_follow_suggestion
+    settings['disable_follow_suggestion']
+  end
 end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -23,6 +23,7 @@ class UserSettings
   setting :hide_federated_timeline, default: false
   setting :hide_remote_timeline, default: false
   setting :show_otadon_tag_cloud, default: true
+  setting :disable_follow_suggestion, default: false
 
   namespace :web do
     setting :advanced_layout, default: false

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -34,6 +34,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:hide_remote_timeline] = object_account_user.hide_remote_timeline
       store[:hide_federated_timeline] = object_account_user.hide_federated_timeline
       store[:show_otadon_tag_cloud] = object_account_user.show_otadon_tag_cloud
+      store[:disable_follow_suggestion] = object_account_user.disable_follow_suggestion
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -85,6 +85,11 @@
     .fields-group
       = ff.input :resized_custom_emoji, collection: ['default', 'hover', 'best', 'fixed_x2', 'fixed_x3'],label_method: lambda { |item| t("simple_form.hints.defaults.display_local_emoji_#{item}") }, hint: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', wrapper: :with_floating_label
 
+    %h4= t 'サジェスト'
+
+    .fields-group
+      = ff.input :disable_follow_suggestion, as: :boolean, wrapper: :with_label
+
     %h4= t 'appearance.discovery'
 
     .fields-group

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -238,6 +238,7 @@ ja:
         hide_local_timeline: ローカルタイムラインを非表示にする
         hide_remote_timeline: リモートタイムラインを非表示にする
         hide_federated_timeline: 連合タイムラインを非表示にする
+        disable_follow_suggestion: フォローを増やしてみませんか？を非表示にする
         show_otadon_tag_cloud: Otadon Hashtag Cloudを表示する
         severity: 重大性
         sign_in_token_attempt: セキュリティコード


### PR DESCRIPTION
- 翻訳を一部修正
- フォロー追加の候補を設定レベルで非表示可能に
- リモートサーバーのユーザページに元サーバーで開けるように