### PR TITLE
ユーザ設定内の無効な設定を削除

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -49,13 +49,6 @@
     .fields-group.fields-row__column.fields-row__column-12
       = ff.input :default_privacy, collection: Status.selectable_visibilities, wrapper: :with_label, include_blank: false, label_method: ->(visibility) { safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') }, required: false, hint: false, label: I18n.t('simple_form.labels.defaults.setting_default_privacy')
 
-    %p.hint= t '通知を受け取る範囲を制限するには以下から設定してください。'
-    .fields-group
-      = f.simple_fields_for :settings, current_user.settings do |ff|
-        = ff.input :'interactions.must_be_follower', wrapper: :with_label, label: I18n.t('simple_form.labels.interactions.must_be_follower')
-        = ff.input :'interactions.must_be_following', wrapper: :with_label, label: I18n.t('simple_form.labels.interactions.must_be_following')
-        = ff.input :'interactions.must_be_following_dm', wrapper: :with_label, label: I18n.t('simple_form.labels.interactions.must_be_following_dm')
-
     %h4= t 'appearance.advanced_web_interface'
 
     %p.hint= t 'appearance.advanced_web_interface_hint'


### PR DESCRIPTION
通知のフィルタリングは、ユーザ設定から通知欄に移行されたため削除